### PR TITLE
Add register and login features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Accessibility Enhanced Learning with AI
    $ npm run dev
    ```
 
-You should now be able to access the app at [http://localhost:3000](http://localhost:3000)! For the full context behind this example app, check out the [tutorial](https://platform.openai.com/docs/quickstart).
+You should now be able to access the app at [http://localhost:3001](http://localhost:3001)! For the full context behind this example app, check out the [tutorial](https://platform.openai.com/docs/quickstart).
 
 ## Setup Backend
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "class-validator": "^0.14.0",
     "joi": "^17.11.0",
     "nestjs-rate-limiter": "^3.1.0",
+    "nestjs-typeorm-paginate": "^4.0.4",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.1",
     "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "joi": "^17.11.0",
     "nestjs-rate-limiter": "^3.1.0",

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import { RegisterDTO } from './dto/registerDto';
 import { UsersService } from '../users/users.service';
 import { UserInsert, SYSTEM_USER } from '../users/entities/user.entity';
 import { firstItem } from 'src/shared/type-helpers';
+import { ServerErrors } from 'src/shared/serverErrors';
 
 @Controller('auth')
 export class AuthController {

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './localAuth.guard';
 import { RegisterDTO } from './dto/registerDto';
 import { UsersService } from '../users/users.service';
+import { UserInsert, SYSTEM_USER } from '../users/entities/user.entity';
 
 @Controller('auth')
 export class AuthController {
@@ -11,16 +12,15 @@ export class AuthController {
     private usersService: UsersService,
   ) {}
 
-  @Post('register')
-  async register(
-    @Body() registerDto: RegisterDTO,
-  ): Promise<{ userId: number }> {
-    const user = await this.usersService.create(
-      registerDto.email,
-      registerDto.password,
-      registerDto.firstName,
-      registerDto.lastName,
-    );
+  @Post('auth/register')
+  async register(@Body() payload: RegisterDTO): Promise<{ userId: number }> {
+    const userData: UserInsert = {
+      ...payload,
+      emailVerificationCode,
+      createdBy: SYSTEM_USER,
+    };
+    const user = await this.usersService.create(userData);
+
     return { userId: user.id };
   }
 
@@ -110,7 +110,7 @@ export class AuthController {
   // }
 
   @UseGuards(LocalAuthGuard)
-  @Post('login')
+  @Post('auth/login')
   async login(@Request() req) {
     // 'req.user' contains the authenticated user information after passing LocalAuthGuard
     return this.authService.login(req.user);

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,10 +1,28 @@
-import { Controller, Post, UseGuards, Request } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards, Request } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './localAuth.guard';
+import { RegisterDTO } from './dto/registerDto';
+import { UsersService } from '../users/users.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private usersService: UsersService,
+  ) {}
+
+  @Post('register')
+  async register(
+    @Body() registerDto: RegisterDTO,
+  ): Promise<{ userId: number }> {
+    const user = await this.usersService.create(
+      registerDto.email,
+      registerDto.password,
+      registerDto.firstName,
+      registerDto.lastName,
+    );
+    return { userId: user.id };
+  }
 
   // @ApiEndpoint({
   //   tags: ['Auth'],

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards, Request } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards, Request, BadRequestException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './localAuth.guard';
 import { RegisterDTO } from './dto/registerDto';
@@ -14,6 +14,17 @@ export class AuthController {
 
   @Post('auth/register')
   async register(@Body() payload: RegisterDTO): Promise<{ userId: number }> {
+    const emailVerificationCode =
+      this.usersService.generateEmailVerificationCode();
+
+    const userWithEmailFromPayload = firstItem(
+      await this.usersService.findByField('email', payload.email),
+    );
+
+    if (userWithEmailFromPayload) {
+      throw new BadRequestException(ServerErrors.EMAIL_EXISTS);
+    }
+
     const userData: UserInsert = {
       ...payload,
       emailVerificationCode,

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,9 +1,17 @@
-import { Body, Controller, Post, UseGuards, Request, BadRequestException } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+  Request,
+  BadRequestException,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './localAuth.guard';
 import { RegisterDTO } from './dto/registerDto';
 import { UsersService } from '../users/users.service';
 import { UserInsert, SYSTEM_USER } from '../users/entities/user.entity';
+import { firstItem } from 'src/shared/type-helpers';
 
 @Controller('auth')
 export class AuthController {

--- a/backend/src/modules/auth/dto/registerDto.ts
+++ b/backend/src/modules/auth/dto/registerDto.ts
@@ -1,0 +1,20 @@
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class RegisterDTO {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(8)
+  password: string;
+
+  @IsNotEmpty()
+  @IsString()
+  firstName: string;
+
+  @IsNotEmpty()
+  @IsString()
+  lastName: string;
+}

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -1,19 +1,63 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { instanceToPlain, Exclude } from 'class-transformer';
+
+export type SystemUser = null;
+export type UserWithId = Pick<User, 'id'>;
+export type UserWithIdOrSystemUser = UserWithId | SystemUser;
+
+export const SYSTEM_USER: SystemUser = null;
+
+export const USERS_TABLE_NAME = 'users';
 
 @Entity()
 export class User {
+  // Only email & password are required fields
+
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({
+    type: 'varchar',
+    length: 100,
+  })
   email: string;
 
-  @Column()
-  password: string; // Consider storing hashed passwords only
+  @Exclude()
+  @Column({
+    type: 'varchar',
+    length: 100,
+  })
+  password: string;
 
-  @Column()
-  firstName: string;
+  @Column({
+    type: 'varchar',
+    length: 100,
+    nullable: true,
+  })
+  @Index()
+  firstName: string | null;
 
-  @Column()
-  lastName: string;
+  @Column({
+    type: 'varchar',
+    length: 100,
+    nullable: true,
+  })
+  @Index()
+  lastName: string | null;
+
+  @Exclude()
+  @Column({
+    type: 'varchar',
+    length: 50,
+    nullable: true,
+  })
+  @Index()
+  emailVerificationCode: string | null;
+
+  @Column({ nullable: false, default: false })
+  emailVerified: boolean;
+
+  toJSON() {
+    return instanceToPlain(this);
+  }
 }

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -5,19 +5,19 @@ import { UsersService } from './users.service';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Post()
-  async addUser(
-    @Body()
-    userData: {
-      email: string;
-      password: string;
-      firstName: string;
-      lastName: string;
-    },
-  ) {
-    const { email, password, firstName, lastName } = userData;
-    return this.usersService.create(email, password, firstName, lastName);
-  }
+  // @Post('users/create')
+  // async addUser(
+  //   @Body()
+  //   userData: {
+  //     email: string;
+  //     password: string;
+  //     firstName: string;
+  //     lastName: string;
+  //   },
+  // ) {
+  //   const { email, password, firstName, lastName } = userData;
+  //   return this.usersService.create(email, password, firstName, lastName);
+  // }
 
   // @Get()
   // async getAllUsers() {

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -16,6 +16,11 @@ export class UsersController {
     },
   ) {
     const { email, password, firstName, lastName } = userData;
-    return this.usersService.createUser(email, password, firstName, lastName);
+    return this.usersService.create(email, password, firstName, lastName);
   }
+
+  // @Get()
+  // async getAllUsers() {
+  //   return this.usersService.findAll();
+  // }
 }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -10,7 +10,7 @@ export class UsersService {
     private usersRepository: Repository<User>,
   ) {}
 
-  async createUser(
+  async create(
     email: string,
     password: string,
     firstName: string,
@@ -28,5 +28,9 @@ export class UsersService {
 
   async findOne(criteria: Partial<User>): Promise<User | undefined> {
     return this.usersRepository.findOneBy(criteria);
+  }
+
+  async generateEmailVerificationCode(): Promise<string> {
+    return Math.random().toString(36).substring(2, 15);
   }
 }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -28,8 +28,19 @@ export class UsersService {
     return newUser;
   }
 
-  async findOne(criteria: Partial<User>): Promise<User | undefined> {
-    return this.usersRepository.findOneBy(criteria);
+  async findAll(): Promise<User[]> {
+    return this.usersRepository.find();
+  }
+
+  async findById(id: number): Promise<User | undefined> {
+    return this.usersRepository.findOneBy({ id });
+  }
+
+  async findByField<F extends keyof User>(
+    field: F,
+    value: User[F],
+  ): Promise<User[]> {
+    return this.usersRepository.findBy({ [field]: value });
   }
 
   async generateEmailVerificationCode(): Promise<string> {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
+import * as bcrypt from 'bcrypt';
+
 
 @Injectable()
 export class UsersService {
@@ -16,9 +18,10 @@ export class UsersService {
     firstName: string,
     lastName: string,
   ): Promise<User> {
+    const hashedPassword = await bcrypt.hash(password, 10);
     const newUser = this.usersRepository.create({
       email,
-      password,
+      password: hashedPassword,
       firstName,
       lastName,
     });
@@ -33,4 +36,6 @@ export class UsersService {
   async generateEmailVerificationCode(): Promise<string> {
     return Math.random().toString(36).substring(2, 15);
   }
+
+  // ^ incorporate this into the create user && register auth service functions
 }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import * as bcrypt from 'bcrypt';
 
-
 @Injectable()
 export class UsersService {
   constructor(

--- a/backend/src/shared/entities/auditable-entity.ts
+++ b/backend/src/shared/entities/auditable-entity.ts
@@ -1,0 +1,129 @@
+import {
+  SystemUser,
+  User,
+  UserWithIdOrSystemUser,
+} from 'src/modules/users/entities/user.entity';
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Index,
+  IsNull,
+  JoinColumn,
+  ManyToOne,
+  UpdateDateColumn,
+} from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { WithAlteredRequired } from '../type-helpers';
+
+export const NOT_DELETED_CONDITION = { deletedAt: IsNull() };
+export const NOT_DELETED_CONDITION_SQL = 'deletedAt IS NULL';
+export const NOT_DELETED_CONDITION_SQL_QUOTED = '"deletedAt" IS NULL';
+
+export enum AuditableEntityFieldName {
+  CreatedAt = 'createdAt',
+  CreatedByUserId = 'createdByUserId',
+  UpdatedAt = 'updatedAt',
+  UpdatedByUserId = 'updatedByUserId',
+  DeletedAt = 'deletedAt',
+  DeletedByUserId = 'deletedByUserId',
+}
+
+export abstract class AuditableEntity extends BaseEntity {
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date;
+
+  /**
+   * TODO: [MIGRATION][AUDITING][INTEGRITY] figure out how to suppress this foreign key from audit shadow log
+   * entities that inherit from this class. (Do not allow onDelete in inherited classes to
+   * CASCADE delete an audit shadow row)
+   */
+  @ManyToOne(() => User, undefined, { cascade: false, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'created_by_user_id' })
+  createdBy?: User | null;
+
+  @Column({
+    name: 'created_by_user_id',
+    /**
+     * null represents the SystemUser
+     */
+    nullable: true,
+  })
+  createdByUserId: number | null;
+
+  @UpdateDateColumn()
+  @Index()
+  updatedAt: Date;
+
+  /**
+   * TODO: [MIGRATION][AUDITING][INTEGRITY] figure out how to suppress this foreign key from audit shadow log
+   * entities that inherit from this class. (Do not allow onDelete in inherited classes to
+   * CASCADE delete an audit shadow row)
+   */
+  @ManyToOne(() => User, undefined, { cascade: false, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'updated_by_user_id' })
+  updatedBy?: User | null;
+
+  @Column({ name: 'updated_by_user_id', nullable: true })
+  updatedByUserId: number | null;
+
+  @DeleteDateColumn()
+  @Index()
+  deletedAt: Date | null;
+
+  /**
+   * The user who deleted this entity
+   *
+   * TODO: [MIGRATION][AUDITING][INTEGRITY] figure out how to suppress this foreign key from audit shadow log
+   * entities that inherit from this class. (Do not allow onDelete in inherited classes to
+   * CASCADE delete an audit shadow row)
+   */
+  @ManyToOne(() => User, undefined, { cascade: false, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'deleted_by_user_id' })
+  deletedBy?: User | null;
+
+  @Column({ name: 'deleted_by_user_id', nullable: true })
+  deletedByUserId: number | null;
+}
+
+export type AuditableEntityInsert<
+  E extends AuditableEntity,
+  // TODO: [TYPE] limit I so that it can only have keys in E
+  I extends QueryDeepPartialEntity<E> = QueryDeepPartialEntity<E>,
+> = WithAlteredRequired<I, 'createdBy', UserWithIdOrSystemUser>
+
+export type AuditableEntityUpdates<T extends AuditableEntity> =
+  WithAlteredRequired<
+    QueryDeepPartialEntity<T>,
+    'updatedBy',
+    | WithAlteredRequired<QueryDeepPartialEntity<User>, 'id', User['id']>
+    | SystemUser
+>;
+
+export type AuditableEntityDeleteUpdates<T extends AuditableEntity> =
+  WithAlteredRequired<
+    QueryDeepPartialEntity<T>,
+    'deletedBy',
+    | WithAlteredRequired<QueryDeepPartialEntity<User>, 'id', User['id']>
+    | SystemUser
+  >;
+
+export enum AuditableEntityRelationsBasic {
+  CREATED_BY = 'createdBy',
+  UPDATED_BY = 'updatedBy',
+  DELETED_BY = 'deletedBy',
+}
+
+type Enum<E> = Record<keyof E, number | string> & Record<number, keyof E>;
+
+// TODO: [TYPE] check that E is an enum
+export type AuditableEntityRelations<E> = AuditableEntityRelationsBasic | E;
+
+export function createAuditableEntityRelations<E extends Enum<E>>(enumBasic: E) {
+  return {
+    ...AuditableEntityRelationsBasic,
+    ...enumBasic,
+  };
+}

--- a/backend/src/shared/entities/auditable-entity.ts
+++ b/backend/src/shared/entities/auditable-entity.ts
@@ -92,7 +92,7 @@ export type AuditableEntityInsert<
   E extends AuditableEntity,
   // TODO: [TYPE] limit I so that it can only have keys in E
   I extends QueryDeepPartialEntity<E> = QueryDeepPartialEntity<E>,
-> = WithAlteredRequired<I, 'createdBy', UserWithIdOrSystemUser>
+> = WithAlteredRequired<I, 'createdBy', UserWithIdOrSystemUser>;
 
 export type AuditableEntityUpdates<T extends AuditableEntity> =
   WithAlteredRequired<
@@ -100,7 +100,7 @@ export type AuditableEntityUpdates<T extends AuditableEntity> =
     'updatedBy',
     | WithAlteredRequired<QueryDeepPartialEntity<User>, 'id', User['id']>
     | SystemUser
->;
+  >;
 
 export type AuditableEntityDeleteUpdates<T extends AuditableEntity> =
   WithAlteredRequired<
@@ -121,7 +121,9 @@ type Enum<E> = Record<keyof E, number | string> & Record<number, keyof E>;
 // TODO: [TYPE] check that E is an enum
 export type AuditableEntityRelations<E> = AuditableEntityRelationsBasic | E;
 
-export function createAuditableEntityRelations<E extends Enum<E>>(enumBasic: E) {
+export function createAuditableEntityRelations<E extends Enum<E>>(
+  enumBasic: E,
+) {
   return {
     ...AuditableEntityRelationsBasic,
     ...enumBasic,

--- a/backend/src/shared/serverErrors.ts
+++ b/backend/src/shared/serverErrors.ts
@@ -1,0 +1,40 @@
+export const ServerError = {
+  Generic: 'Something went wrong',
+  RefreshTokenNotFound: 'Refresh token not found',
+  RefreshTokenExpired: 'Refresh token has expired',
+  PasswordResetTokenExpired: 'Password reset token has expired',
+  PasswordResetTokenNotExpired: 'Another password reset request is pending. Please check your email',
+  PasswordResetTokenNotFound: 'Password reset token not found',
+  NothingChanged: 'Nothing changed',
+  NothingToChange: 'Nothing to change',
+  UnexpectedMatchedEntitiesCount:
+    'The number of matched entities was different than expected',
+};
+
+export const ServerErrors = {
+  ACCESS_DENIED: 'Access denied',
+  INACTIVE_ACCOUNT: 'User account not active',
+  USER_NOT_FOUND: 'User not found',
+  NOT_FOUND: 'Not found',
+  JWT_EXPIRED_OR_NOT_FOUND:
+    'Authorization header not found or jwt token has expired',
+  FAILED_VALIDATION: 'Failed validation',
+  EMAIL_EXISTS: 'The email already exists',
+  EMAIL_NOT_VERIFIED:
+    'This email has not been verified. Please check your email',
+  INVALID_CREDENTIALS: 'Invalid credentials',
+  LOGIN_EXCEED: 'Maximum login attempts reached. Please contact an admin to reset your password',
+  INCORRECT_OLD_PASSWORD: 'Incorrect old password',
+  NO_UPDATE_DELETED: 'Deleted entity cannot be updated',
+  VERIFICATION_CODE_NOT_FOUND:
+    'Email verification code not found. '
+    + 'You may get this message if your email is already confirmed',
+  ALREADY_MARKED_DELETED: 'Already marked as deleted',
+  REFRESH_TOKEN_EXPIRED: ServerError.RefreshTokenExpired,
+  REFRESH_TOKEN_NOT_FOUND: ServerError.RefreshTokenNotFound,
+  PASSWORD_RESET_TOKEN_EXPIRED: ServerError.PasswordResetTokenExpired,
+  PASSWORD_RESET_TOKEN_NOT_FOUND: ServerError.PasswordResetTokenNotFound,
+  PASSWORD_RESET_TOKEN_NOT_EXPIRED: ServerError.PasswordResetTokenNotExpired,
+  USER_EMAIL_NOT_FOUND: 'User email not found',
+  STATUS_NOT_CHANGED: 'Status is already set to that value',
+};

--- a/backend/src/shared/type-helpers.ts
+++ b/backend/src/shared/type-helpers.ts
@@ -1,0 +1,400 @@
+import { Pagination } from 'nestjs-typeorm-paginate';
+import { BaseEntity, DeepPartial } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { AuditableEntity } from './entities/auditable-entity';
+
+export type ExpandArrayElement<T> = T extends Date
+  ? T
+  : // TODO: [TYPE] handle case where function also has properties
+    T extends Function
+    ? T
+    : T extends object
+      ? T extends infer O
+        ? { [K in keyof O]: O[K] }
+        : never
+      : T;
+
+// expands object types one level deep
+export type Expand<T> = T extends Date
+  ? T
+  : // TODO: [TYPE] handle case where array also has properties
+    T extends Array<infer E>
+    ? Array<ExpandArrayElement<E>>
+    : // TODO: [TYPE] handle case where function also has properties
+      T extends Function
+      ? T
+      : T extends object
+        ? T extends infer O
+          ? { [K in keyof O]: O[K] }
+          : never
+        : T;
+export type Expand2<T> = T extends Date
+  ? T
+  : // TODO: [TYPE] handle case where array also has properties
+    T extends Array<infer E>
+    ? Array<Expand<E>>
+    : // TODO: [TYPE] handle case where function also has properties
+      T extends Function
+      ? T
+      : T extends object
+        ? T extends infer O
+          ? { [K in keyof O]: Expand<O[K]> }
+          : never
+        : T;
+export type Expand3<T> = T extends Date
+  ? T
+  : // TODO: [TYPE] handle case where array also has properties
+    T extends Array<infer E>
+    ? Array<Expand2<E>>
+    : // TODO: [TYPE] handle case where function also has properties
+      T extends Function
+      ? T
+      : T extends object
+        ? T extends infer O
+          ? { [K in keyof O]: Expand2<O[K]> }
+          : never
+        : T;
+
+// expands object types recursively
+export type ExpandRecursively<T> = T extends Date
+  ? T
+  : // TODO: [TYPE] handle case where array also has properties
+    T extends Array<infer E>
+    ? Array<ExpandRecursively<E>>
+    : // TODO: [TYPE] handle case where function also has properties
+      T extends Function
+      ? T
+      : T extends object
+        ? T extends infer O
+          ? { [K in keyof O]: ExpandRecursively<O[K]> }
+          : never
+        : T;
+export type Await<T> = T extends {
+  then(onfulfilled?: (value: infer U) => unknown): unknown;
+}
+  ? U
+  : T;
+
+export type UnwrapArrayElement<T extends Array<unknown>> = T extends Array<
+  infer U
+>
+  ? U
+  : undefined;
+
+export type UnwrapPaginationItem<T extends Pagination<unknown>> =
+  T extends Pagination<infer U> ? U : undefined;
+
+export type WithRequired<T extends object, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: T[P];
+};
+
+export type WithOptional<T extends object, K extends keyof T> = Omit<T, K> & {
+  [P in K]?: T[P];
+};
+
+export type OptionalPropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]> ? never : K;
+  }[keyof T],
+  undefined
+>;
+
+export type RequiredPropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]> ? K : never;
+  }[keyof T],
+  undefined
+>;
+
+export type RequiredNotNullablePropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]>
+      ? null extends T[K]
+        ? never
+        : undefined extends T[K]
+          ? never
+          : K
+      : never;
+  }[keyof T],
+  undefined
+>;
+
+export type RequiredNullablePropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]>
+      ? null extends T[K]
+        ? K
+        : undefined extends T[K]
+          ? K
+          : never
+      : never;
+  }[keyof T],
+  undefined
+>;
+
+export type FunctionPropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T[K] extends Function ? K : never;
+  }[keyof T],
+  undefined
+>;
+
+export type ExcludeAllOptional<T extends object> = {
+  [K in RequiredPropertyOf<T>]: T[K];
+};
+
+export type PickEntity<T extends BaseEntity, K extends keyof T> = Pick<
+  T,
+  K | keyof BaseEntity
+>;
+
+export type PickEntityRequired<
+  T extends BaseEntity,
+  K extends keyof T,
+> = Required<PickEntity<T, K>>;
+
+export type PickEntityOptional<
+  T extends BaseEntity,
+  K extends keyof T,
+> = Partial<PickEntity<T, K>>;
+
+export type EntityBasics<T extends BaseEntity> = ExcludeAllOptional<T> &
+  Pick<T, keyof BaseEntity>;
+
+export type PickRequired<T extends object, K extends keyof T> = Required<
+  Pick<T, K>
+>;
+
+export type PickOptional<T extends object, K extends keyof T> = Partial<
+  Pick<T, K>
+>;
+
+export type PickNotNullRequired<T extends object, K extends keyof T> = Required<
+  PickNotNull<T, K>
+>;
+
+export type NotNull<T> = Exclude<T, null>;
+
+export type NotNullDueToAppLogic<T> = NotNull<T>;
+
+export type NotUndefined<T> = Exclude<T, undefined>;
+
+export type NotNullOrUndefined<T> = NonNullable<T>;
+
+export type PickAltered<T extends object, K extends keyof T, A> = {
+  [P in K]: A;
+};
+
+export type PickNotNull<T extends object, K extends keyof T> = {
+  [P in K]: NotNull<T[P]>;
+};
+
+export type PickAlteredRequired<
+  T extends object,
+  K extends keyof T,
+  A,
+> = Required<PickAltered<T, K, A>>;
+
+export type PickAlteredOptional<
+  T extends object,
+  K extends keyof T,
+  A,
+> = Partial<PickAltered<T, K, A>>;
+
+export type WithAltered<T extends object, K extends keyof T, A> = Omit<T, K> & {
+  [P in K]: A;
+};
+
+export type WithAlteredOptional<T extends object, K extends keyof T, A> = Omit<
+  T,
+  K
+> & {
+  [P in K]?: A;
+};
+
+export type WithAlteredRequired<T extends object, K extends keyof T, A> = Omit<
+  T,
+  K
+> & {
+  [P in K]-?: A;
+};
+
+export type WithNotNull<T extends object, K extends keyof T> = Omit<T, K> & {
+  [P in K]: NotNull<T[P]>;
+};
+
+export type WithNotNullRequired<T extends object, K extends keyof T> = Omit<
+  T,
+  K
+> & {
+  [P in K]-?: NotNull<T[P]>;
+};
+
+export type InsertEntity<T extends object> = {
+  [K in keyof T]: T[K] | (() => string);
+};
+
+/**
+ * TODO: [TYPE] only make certain types InsertEntity, like Date. Perhaps provide a list of
+ * exclusions or inclusions to apply InsertEntity to.
+ */
+export type InsertDefaults<
+  T extends AuditableEntity,
+  Defaulted extends keyof T = never,
+> = InsertEntity<
+  Omit<
+    Pick<T, Exclude<RequiredNotNullablePropertyOf<T>, Defaulted>> &
+      PickOptional<T, Exclude<RequiredNullablePropertyOf<T>, Defaulted>> &
+      PickOptional<T, Defaulted>,
+    keyof AuditableEntity | 'id' | FunctionPropertyOf<T>
+  >
+>;
+
+export type KeyOf<T extends object, K extends keyof T> = K;
+
+export type OmitProps<T extends object, K extends keyof T> = Omit<T, K>;
+
+export type OmitFunctionProps<T extends object> = OmitProps<
+  T,
+  FunctionPropertyOf<T>
+>;
+
+export type Optional<T> = T | undefined;
+
+export type Nullable<T> = T | null;
+
+export type NullIfDeleted<T> = Nullable<T>;
+
+export type PickAsNullIfDeleted<
+  T extends object,
+  K extends keyof T,
+> = PickAltered<T, K, NullIfDeleted<T[K]>>;
+
+export type PickAsNullIfDeletedRequired<
+  T extends object,
+  K extends keyof T,
+> = PickAlteredRequired<T, K, NullIfDeleted<T[K]>>;
+
+export type PickAsNullIfDeletedOptional<
+  T extends object,
+  K extends keyof T,
+> = PickAlteredOptional<T, K, NullIfDeleted<T[K]>>;
+
+export type WithAsNullIfDeleted<T extends object, K extends keyof T> = Omit<
+  T,
+  K
+> &
+  PickAsNullIfDeleted<T, K>;
+
+export type WithAsNullIfDeletedRequired<
+  T extends object,
+  K extends keyof T,
+> = Omit<T, K> & PickAsNullIfDeletedRequired<T, K>;
+
+export type WithAsNullIfDeletedOptional<
+  T extends object,
+  K extends keyof T,
+> = Omit<T, K> & PickAsNullIfDeletedOptional<T, K>;
+
+/**
+ * A convenient way to cast safely.
+ */
+export function asType<T>(t: T) {
+  return t;
+}
+
+/**
+ * NOTE: I don't get why this works in some cases where asType<DeepPartial<T>>(t) does not.
+ */
+export function asDeepPartial<T>(t: T) {
+  return asType<DeepPartial<T>>(t);
+}
+
+export function asQueryDeepPartialEntity<T>(t: T) {
+  return asType<QueryDeepPartialEntity<T>>(t);
+}
+
+/**
+ * Safely access an array by index. Returns undefined if the item does not exist.
+ */
+export function itemAtIndex<T>(index: number, array: T[]): T | undefined;
+export function itemAtIndex<T>(
+  index: number,
+  array: T[],
+  assertExists: false,
+): T | undefined;
+export function itemAtIndex<T>(
+  index: number,
+  array: T[],
+  assertExists: true,
+): T;
+export function itemAtIndex<T>(
+  index: number,
+  array: T[],
+  assertExists?: boolean,
+) {
+  if (assertExists) {
+    if (index < 0 || index > array.length) {
+      throw new Error('index is out of array bounds');
+    }
+  }
+  const value = array[index];
+  if (assertExists) {
+    return value as T;
+  }
+
+  return value as T | undefined;
+}
+
+export function firstItem<T>(array: T[]): T | undefined;
+export function firstItem<T>(array: T[], assertExists: false): T | undefined;
+export function firstItem<T>(array: T[], assertExists: true): T;
+export function firstItem<T>(
+  array: T[],
+  assertExists?: boolean,
+): T | undefined {
+  const index = 0;
+  if (assertExists) {
+    return itemAtIndex(index, array, assertExists);
+  }
+  return itemAtIndex(index, array);
+}
+
+export function lastItem<T>(array: T[]): T | undefined;
+export function lastItem<T>(array: T[], assertExists: false): T | undefined;
+export function lastItem<T>(array: T[], assertExists: true): T;
+export function lastItem<T>(array: T[], assertExists?: boolean): T | undefined {
+  const index = array.length - 1;
+  if (assertExists) {
+    return itemAtIndex(index, array, assertExists);
+  }
+  return itemAtIndex(index, array);
+}
+
+export function assertTruthy(arg: any): asserts arg {
+  if (!arg) {
+    throw new Error('Expected truthy');
+  }
+  return arg;
+}
+
+export function assertNotNull<T>(arg: T): asserts arg is Exclude<T, null> {
+  if (arg === null) {
+    throw new Error('Expected not null');
+  }
+}
+
+export function assertNotUndefined<T>(
+  arg: T,
+): asserts arg is Exclude<T, undefined> {
+  if (arg === undefined) {
+    throw new Error('Expected not undefined');
+  }
+}
+
+export function assertNotNullAndNotUndefined<T>(
+  arg: T,
+): asserts arg is Exclude<T, null | undefined> {
+  assertNotNull(arg);
+  assertNotUndefined(arg);
+}

--- a/interface/package.json
+++ b/interface/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
-    "start": "next start -p $PORT",
+    "start": "next start -p 3001",
     "lint": "next lint",
     "export": "next build && next export",
     "setup-deploy": "chmod +x ./scripts/deploy.sh",

--- a/interface/src/pages/login.tsx
+++ b/interface/src/pages/login.tsx
@@ -4,13 +4,15 @@ import { Button, TextField, Container, Typography, IconButton, InputAdornment } 
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import Joi from 'joi';
-import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [emailError, setEmailError] = useState(false);
+
+  const router = useRouter();
 
   const schema = Joi.object({
     email: Joi.string().email({ tlds: { allow: false } }).required(),
@@ -63,7 +65,13 @@ export default function Login() {
         Login
       </Button>
       <Typography variant="body1" marginTop={2}>
-        If you do not have an account yet, please <Link href="/register"><a>Sign Up</a></Link>.
+        If you do not have an account yet, please 
+        <Button 
+          color="primary" 
+          onClick={() => router.push('/register')}
+        >
+          Sign Up
+        </Button>.
       </Typography>
     </Container>
   );

--- a/interface/src/pages/register.tsx
+++ b/interface/src/pages/register.tsx
@@ -8,23 +8,31 @@ import Joi from 'joi';
 export default function Register() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [emailError, setEmailError] = useState(false);
   const [passwordError, setPasswordError] = useState(false);
+  const [firstNameError, setFirstNameError] = useState(false);
+  const [lastNameError, setLastNameError] = useState(false);
 
   const schema = Joi.object({
     email: Joi.string().email({ tlds: { allow: false } }).required(),
     password: Joi.string().min(8).pattern(new RegExp('^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*]).*$')).required(),
+    firstName: Joi.string().required(),
+    lastName: Joi.string().required(),
   });
 
   const handleRegister = async () => {
-    const { error } = schema.validate({ email, password });
+    const { error } = schema.validate({ email, password, firstName, lastName });
     setEmailError(!!error?.details.find(d => d.path.includes('email')));
     setPasswordError(!!error?.details.find(d => d.path.includes('password')));
+    setFirstNameError(!!error?.details.find(d => d.path.includes('firstName')));
+    setLastNameError(!!error?.details.find(d => d.path.includes('lastName')));
 
     if (!error) {
       try {
-        const response = await axios.post('/api/register', { email, password });
+        const response = await axios.post('/api/register', { email, password, firstName, lastName });
         console.log('User registered:', response.data);
         // Handle success (e.g., navigate to login page or dashboard)
       } catch (error) {
@@ -37,6 +45,26 @@ export default function Register() {
   return (
     <Container maxWidth="sm">
       <Typography variant="h4" gutterBottom>Create your account</Typography>
+      <TextField
+        label="First Name"
+        variant="outlined"
+        fullWidth
+        margin="normal"
+        value={firstName}
+        onChange={(e) => setFirstName(e.target.value)}
+        error={firstNameError}
+        helperText={firstNameError ? "First name is required" : ""}
+      />
+      <TextField
+        label="Last Name"
+        variant="outlined"
+        fullWidth
+        margin="normal"
+        value={lastName}
+        onChange={(e) => setLastName(e.target.value)}
+        error={lastNameError}
+        helperText={lastNameError ? "Last name is required" : ""}
+      />
       <TextField
         error={emailError}
         helperText={emailError ? "Invalid email address" : ""}

--- a/interface/tests/fixtures/url.ts
+++ b/interface/tests/fixtures/url.ts
@@ -1,4 +1,4 @@
 // url constants used in tests
 
-export const ALAI_BASE_URL = 'http://localhost:3000';
+export const ALAI_BASE_URL = 'http://localhost:3001';
 export const ALAI_LOGIN_URL = `${ALAI_BASE_URL}/login`;


### PR DESCRIPTION
## What does this PR do?
- Updated npm run dev and start scripts to run frontend interface on localhost 3001, instead of 3000.
- Add register with registerDto to auth module.
- Add register page with first name, last name, email, password. Include error state as well.
- Add login page with email and password.
- Base user entity off auditable entity.


## How was this PR tested?
Testing of backend service and api remains.


## Screenshots and/or Loom
[Screenshots or Loom videos of changes]
